### PR TITLE
Azure Active Directory integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.terraform
+terraform.tfstate
+terraform.tfstate.backup

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -1,0 +1,8 @@
+# Release notes
+
+## Changelog
+
+Changes between `1.0.0` and this release: `1.1.0`
+
+- Add Active directory integration. 
+Please, read the documentation to understand the change: https://kubernetesfury.com/docs/installers/managed/aks/

--- a/example/main.tf
+++ b/example/main.tf
@@ -54,7 +54,7 @@ preferences: {}
 users:
 - name: aks
   user:
-    client-certificate-data: ${data.azurerm_kubernetes_cluster.aks.kube_config.0.client_certificate}
-    client-key-data: ${data.azurerm_kubernetes_cluster.aks.kube_config.0.client_key}
+    client-certificate-data: ${data.azurerm_kubernetes_cluster.aks.kube_admin_config.0.client_certificate}
+    client-key-data: ${data.azurerm_kubernetes_cluster.aks.kube_admin_config.0.client_key}
 EOT
 }

--- a/modules/aks/README.md
+++ b/modules/aks/README.md
@@ -2,10 +2,10 @@
 
 | Name    | Version |
 | ------- | ------- |
-| azuread | >=0.8   |
-| azurerm | 2.5.0   |
+| azuread | >= 0.8  |
+| azurerm | >= 2.10 |
 | null    | >= 2.1  |
-| random  | >=2.2   |
+| random  | >= 2.2  |
 
 ## Inputs
 

--- a/modules/aks/README.md
+++ b/modules/aks/README.md
@@ -1,11 +1,12 @@
 ## Providers
 
-| Name    | Version |
-| ------- | ------- |
-| azuread | >= 0.8  |
-| azurerm | >= 2.10 |
-| null    | >= 2.1  |
-| random  | >= 2.2  |
+| Name       | Version |
+| ---------- | ------- |
+| azuread    | >= 0.8  |
+| azurerm    | >= 2.10 |
+| kubernetes | >= 1.11 |
+| null       | >= 2.1  |
+| random     | >= 2.2  |
 
 ## Inputs
 

--- a/modules/aks/aad.tf
+++ b/modules/aks/aad.tf
@@ -1,0 +1,138 @@
+resource "azuread_application" "aad_server" {
+  name = "${var.cluster_name}-aks-aad-server"
+
+  reply_urls = [
+    "http://${var.cluster_name}-aks-aad-server",
+  ]
+
+  type = "webapp/api"
+
+  # this is important, as stated by the documentation
+  group_membership_claims = "All"
+
+  required_resource_access {
+    # Windows Azure Active Directory API
+    resource_app_id = "00000002-0000-0000-c000-000000000000"
+
+    resource_access {
+      # DELEGATED PERMISSIONS: "Sign in and read user profile":
+      # 311a71cc-e848-46a1-bdf8-97ff7156d8e6
+      id = "311a71cc-e848-46a1-bdf8-97ff7156d8e6"
+
+      type = "Scope"
+    }
+  }
+
+  required_resource_access {
+    # MicrosoftGraph API
+    resource_app_id = "00000003-0000-0000-c000-000000000000"
+
+    # APPLICATION PERMISSIONS: "Read directory data":
+    # 7ab1d382-f21e-4acd-a863-ba3e13f7da61
+    resource_access {
+      id   = "7ab1d382-f21e-4acd-a863-ba3e13f7da61"
+      type = "Role"
+    }
+
+    # DELEGATED PERMISSIONS: "Sign in and read user profile":
+    # e1fe6dd8-ba31-4d61-89e7-88639da4683d
+    resource_access {
+      id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"
+      type = "Scope"
+    }
+
+    # DELEGATED PERMISSIONS: "Read directory data":
+    # 06da0dbc-49e2-44d2-8312-53f166ab848a
+    resource_access {
+      id   = "06da0dbc-49e2-44d2-8312-53f166ab848a"
+      type = "Scope"
+    }
+  }
+}
+
+resource "azuread_service_principal" "aad_server" {
+  application_id = azuread_application.aad_server.application_id
+}
+
+resource "random_string" "aad_server" {
+  length  = 16
+  special = true
+
+  keepers = {
+    service_principal = azuread_service_principal.aad_server.id
+  }
+}
+
+resource "azuread_service_principal_password" "aad_server" {
+  service_principal_id = azuread_service_principal.aad_server.id
+  value                = random_string.aad_server.result
+  end_date             = timeadd(timestamp(), "8760h")
+
+  # This stops be 'end_date' changing on each run and causing a new password to be set
+  # to get the date to change here you would have to manually taint this resource...
+  lifecycle {
+    ignore_changes = [end_date]
+  }
+}
+
+resource "azuread_application" "aad_client" {
+  name = "${var.cluster_name}-aks-aad-client"
+
+  reply_urls = [
+    "http://${var.cluster_name}-aks-aad-client",
+  ]
+
+  # This is necessary that the client app is of type "native".
+  # Only allowed since the 0.4.0 version of the azuread Terraform provider.
+  type = "native"
+
+  required_resource_access {
+    # Windows Azure Active Directory API
+    resource_app_id = "00000002-0000-0000-c000-000000000000"
+
+    resource_access {
+      # DELEGATED PERMISSIONS: "Sign in and read user profile":
+      # 311a71cc-e848-46a1-bdf8-97ff7156d8e6
+      id = "311a71cc-e848-46a1-bdf8-97ff7156d8e6"
+
+      type = "Scope"
+    }
+  }
+
+  # This is where we allow the client app to do requets to the server app.
+  required_resource_access {
+    # AKS ad application server
+    resource_app_id = azuread_application.aad_server.application_id
+
+    resource_access {
+      # Server app Oauth2 permissions id
+      id   = lookup(azuread_application.aad_server.oauth2_permissions[0], "id")
+      type = "Scope"
+    }
+  }
+}
+
+resource "azuread_service_principal" "aad_client" {
+  application_id = azuread_application.aad_client.application_id
+}
+
+resource "random_string" "aad_client" {
+  length  = 16
+  special = true
+
+  keepers = {
+    service_principal = azuread_service_principal.aad_client.id
+  }
+}
+
+resource "azuread_service_principal_password" "client" {
+  service_principal_id = azuread_service_principal.aad_client.id
+  value                = random_string.aad_client.result
+  end_date             = timeadd(timestamp(), "8760h")
+
+  # This stops be 'end_date' changing on each run and causing a new password to be set
+  # to get the date to change here you would have to manually taint this resource...
+  lifecycle {
+    ignore_changes = [end_date]
+  }
+}

--- a/modules/aks/cluster.tf
+++ b/modules/aks/cluster.tf
@@ -76,8 +76,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   node_resource_group = "${data.azurerm_resource_group.aks.name}-nodes"
 
-  #private_cluster_enabled = true # 2.7
-  private_link_enabled = true # 2.5
+  private_cluster_enabled = true
 
   role_based_access_control {
     enabled = false

--- a/modules/aks/cluster.tf
+++ b/modules/aks/cluster.tf
@@ -79,7 +79,13 @@ resource "azurerm_kubernetes_cluster" "aks" {
   private_cluster_enabled = true
 
   role_based_access_control {
-    enabled = false
+    enabled = true
+
+    azure_active_directory {
+      client_app_id     = azuread_application.aad_client.application_id
+      server_app_id     = azuread_application.aad_server.application_id
+      server_app_secret = azuread_service_principal_password.aad_server.value
+    }
   }
 
   lifecycle {

--- a/modules/aks/main.tf
+++ b/modules/aks/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     kubernetes = ">= 1.11.1"
     azuread    = ">=0.8"
-    azurerm    = "2.5.0"
+    azurerm    = ">=2.10"
     random     = ">=2.2"
     null       = ">= 2.1"
   }


### PR DESCRIPTION
The aim of this PR is to add Azure Active Directory (AAD) integration with the AKS cluster created by the installer to allow RBAC fine-grained control using users and groups from AAD. I think this is an essential feature for our enterprise customers.

**⚠ Warning**:
the first time the user will try to create the cluster, the process will fail because the "server" application that connects to AAD needs to be granted consent from a directory administrator. This could be automated in hackish ways (using `local-exec`) but it won't always work because it's not granted that who is creating the cluster is also an AAD admin, furthermore I don't think it's worth to automate it because it defeats the whole purpose of manually granting access to sensible resources in AAD.