### PR TITLE
pin kubernetes provider as it contains breaking changes on v2

### DIFF
--- a/modules/aks/README.md
+++ b/modules/aks/README.md
@@ -2,7 +2,7 @@
 
 | Name       | Version   |
 | ---------- | --------- |
-| kubernetes | >= 1.13.2 |
+| kubernetes |  = 1.13.3 |
 | azuread    | >= 1.0.0  |
 | azurerm    | >= 2.33.0 |
 | null       | >= 3.0.0  |

--- a/modules/aks/main.tf
+++ b/modules/aks/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 0.12.0"
   required_providers {
-    kubernetes = ">= 1.13.2"
+    kubernetes = "= 1.13.3"
     azuread    = ">= 1.0.0"
     azurerm    = ">= 2.33.0"
     random     = ">= 3.0.0"


### PR DESCRIPTION
As said in the title, @nikever found an issue while using the eks installer related to the kubernetes provider.
Let's ping the version to a static one (latest v1 version)